### PR TITLE
Implement Unix pid maps for `winedbg`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ proton-tkg/gecko/
 proton-tkg/proton_tkg_token
 proton-tkg/external-resources
 proton-tkg/gst/
+.DS_Store

--- a/wine-tkg-git/wine-tkg-patches/misc/implement-unix-pid-maps-in-winedbg/implement-unix-pid-maps-in-winedbg.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/implement-unix-pid-maps-in-winedbg/implement-unix-pid-maps-in-winedbg.patch
@@ -1,0 +1,275 @@
+From 3d27fae698c4217fa04292cd043cf4bf8fb97bd9 Mon Sep 17 00:00:00 2001
+From: marzent <marc_aurel@me.com>
+Date: Wed, 20 Apr 2022 00:16:19 +0200
+Subject: [PATCH] implement unix pid maps in winedbg
+
+---
+ .gitignore                  |   1 +
+ programs/winedbg/dbg.y      |   3 +-
+ programs/winedbg/debug.l    |   1 +
+ programs/winedbg/debugger.h |   1 +
+ programs/winedbg/info.c     | 167 ++++++++++++++++++++++++++++++++++++
+ 5 files changed, 172 insertions(+), 1 deletion(-)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 00000000000..fd5106ff27b
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1 @@
++.DS_STORE
+diff --git a/programs/winedbg/dbg.y b/programs/winedbg/dbg.y
+index ad21e3b81c5..b1199c18f03 100644
+--- a/programs/winedbg/dbg.y
++++ b/programs/winedbg/dbg.y
+@@ -52,7 +52,7 @@ static void parser(const char*);
+ %token tENABLE tDISABLE tBREAK tHBREAK tWATCH tRWATCH tDELETE tSET tPRINT tEXAM
+ %token tABORT tECHO
+ %token tCLASS tMAPS tSTACK tSEGMENTS tSYMBOL tREGS tALLREGS tWND tLOCAL tEXCEPTION
+-%token tPROCESS tTHREAD tEOL tEOF
++%token tPROCESS tPROCESSMAP tTHREAD tEOL tEOF
+ %token tFRAME tSHARE tMODULE tCOND tDISPLAY tUNDISPLAY tDISASSEMBLE
+ %token tSTEPI tNEXTI tFINISH tSHOW tDIR tWHATIS tSOURCE
+ %token <string> tPATH tIDENTIFIER tSTRING tINTVAR
+@@ -284,6 +284,7 @@ info_command:
+     | tINFO '*' tWND            { info_win32_window(NULL, TRUE); }
+     | tINFO '*' tWND expr_rvalue { info_win32_window((HWND)(DWORD_PTR)$4, TRUE); }
+     | tINFO tPROCESS            { info_win32_processes(); }
++    | tINFO tPROCESSMAP         { info_win32_processes_map(); }
+     | tINFO tTHREAD             { info_win32_threads(); }
+     | tINFO tFRAME              { info_win32_frame_exceptions(dbg_curr_tid); }
+     | tINFO tFRAME expr_rvalue  { info_win32_frame_exceptions($3); }
+diff --git a/programs/winedbg/debug.l b/programs/winedbg/debug.l
+index 280013799c9..68e433a0b2b 100644
+--- a/programs/winedbg/debug.l
++++ b/programs/winedbg/debug.l
+@@ -215,6 +215,7 @@ STRING     \"(\\[^\n]|[^\\"\n])*\"
+ <INFO_CMD>locals|local|loca|loc		{ return tLOCAL; }
+ <INFO_CMD>class|clas|cla                { return tCLASS; }
+ <INFO_CMD>process|proces|proce|proc   	{ return tPROCESS; }
++<INFO_CMD>processmap|procesmap|procemap|procmap       { return tPROCESSMAP; }
+ <INFO_CMD>threads|thread|threa|thre|thr|th { return tTHREAD; }
+ <INFO_CMD>exception|except|exc|ex	{ return tEXCEPTION; }
+ <INFO_CMD>registers|regs|reg|re		{ return tREGS; }
+diff --git a/programs/winedbg/debugger.h b/programs/winedbg/debugger.h
+index 1ae2dce4689..e308183793c 100644
+--- a/programs/winedbg/debugger.h
++++ b/programs/winedbg/debugger.h
+@@ -382,6 +382,7 @@ extern void             info_win32_module(DWORD64 mod);
+ extern void             info_win32_class(HWND hWnd, const char* clsName);
+ extern void             info_win32_window(HWND hWnd, BOOL detailed);
+ extern void             info_win32_processes(void);
++extern void             info_win32_processes_map(void);
+ extern void             info_win32_threads(void);
+ extern void             info_win32_frame_exceptions(DWORD tid);
+ extern void             info_win32_virtual(DWORD pid);
+diff --git a/programs/winedbg/info.c b/programs/winedbg/info.c
+index bb933aeb455..2b2382c6c11 100644
+--- a/programs/winedbg/info.c
++++ b/programs/winedbg/info.c
+@@ -29,6 +29,7 @@
+ #include "winuser.h"
+ #include "tlhelp32.h"
+ #include "wine/debug.h"
++#include "wine/server.h"
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(winedbg);
+ 
+@@ -100,6 +101,7 @@ void info_help(void)
+             "  info locals          Displays values of all local vars for current frame",
+             "  info maps <pid>      Shows virtual mappings (in a given process)",
+             "  info process         Shows all running processes",
++            "  info processmap      Shows a windows to unix process map",
+             "  info reg             Displays values of the general registers at top of stack",
+             "  info all-reg         Displays the general and floating point registers",
+             "  info segments <pid>  Displays information about all known segments",
+@@ -483,6 +485,81 @@ struct dump_proc
+     unsigned               alloc;
+ };
+ 
++struct pid_map
++{
++    unsigned int pid;
++    unsigned int unix_pid;
++};
++
++static struct pid_map *get_pid_map( unsigned int *num_entries )
++{
++    struct pid_map *map;
++    unsigned int i = 0, map_count = 16, buffer_len = 4096, process_count, pos = 0;
++    NTSTATUS ret;
++    char *buffer = NULL, *new_buffer;
++
++    if (!(buffer = HeapAlloc( GetProcessHeap(), 0, buffer_len ))) return NULL;
++
++    for (;;)
++    {
++        SERVER_START_REQ( list_processes )
++        {
++            wine_server_set_reply( req, buffer, buffer_len );
++            ret = wine_server_call( req );
++            buffer_len = reply->info_size;
++            process_count = reply->process_count;
++        }
++        SERVER_END_REQ;
++
++        if (ret != STATUS_INFO_LENGTH_MISMATCH) break;
++
++        if (!(new_buffer = HeapReAlloc( GetProcessHeap(), 0, buffer, buffer_len )))
++        {
++            HeapFree( GetProcessHeap(), 0, buffer );
++            return NULL;
++        }
++        buffer = new_buffer;
++    }
++
++    if (!(map = HeapAlloc( GetProcessHeap(), 0, map_count * sizeof(*map) )))
++    {
++        HeapFree( GetProcessHeap(), 0, buffer );
++        return NULL;
++    }
++
++    for (i = 0; i < process_count; ++i)
++    {
++        const struct process_info *process;
++
++        pos = (pos + 7) & ~7;
++        process = (const struct process_info *)(buffer + pos);
++
++        if (i >= map_count)
++        {
++            struct pid_map *new_map;
++            map_count *= 2;
++            if (!(new_map = HeapReAlloc( GetProcessHeap(), 0, map, map_count * sizeof(*map))))
++            {
++                HeapFree( GetProcessHeap(), 0, map );
++                HeapFree( GetProcessHeap(), 0, buffer );
++                return NULL;
++            }
++            map = new_map;
++        }
++
++        map[i].pid = process->pid;
++        map[i].unix_pid = process->unix_pid;
++
++        pos += sizeof(struct process_info) + process->name_len;
++        pos = (pos + 7) & ~7;
++        pos += process->thread_count * sizeof(struct thread_info);
++    }
++
++    HeapFree( GetProcessHeap(), 0, buffer );
++    *num_entries = process_count;
++    return map;
++}
++
+ static unsigned get_parent(const struct dump_proc* dp, unsigned idx)
+ {
+     unsigned i;
+@@ -517,6 +594,48 @@ static void dump_proc_info(const struct dump_proc* dp, unsigned idx, unsigned de
+     }
+ }
+ 
++static unsigned int find_unix_pid( struct pid_map *map, unsigned int num_entries, unsigned int pid )
++{
++    unsigned int i;
++    
++    for (i = 0; i < num_entries; i++)
++        if (map[i].pid == pid)
++            return map[i].unix_pid;
++    
++    return 0;
++}
++
++static void dump_proc_info_map(const struct dump_proc* dp, unsigned idx, unsigned depth)
++{
++    struct pid_map *map = NULL;
++    struct dump_proc_entry* dpe;
++    unsigned int num_entries = 0;
++    
++    map = get_pid_map( &num_entries );
++    
++    for ( ; idx != -1; idx = dp->entries[idx].sibling)
++    {
++        assert(idx < dp->count);
++        dpe = &dp->entries[idx];
++        dbg_printf("%c%08lx %08x %-8ld ",
++                   (dpe->proc.th32ProcessID == (dbg_curr_process ?
++                                                dbg_curr_process->pid : 0)) ? '>' : ' ',
++                   dpe->proc.th32ProcessID,
++                   find_unix_pid(map, num_entries, dpe->proc.th32ProcessID),
++                   dpe->proc.cntThreads);
++        if (depth)
++        {
++            unsigned i;
++            for (i = 3 * (depth - 1); i > 0; i--) dbg_printf(" ");
++            dbg_printf("\\_ ");
++        }
++        dbg_printf("'%s'\n", dpe->proc.szExeFile);
++        dump_proc_info_map(dp, dpe->children, depth + 1);
++    }
++    
++    HeapFree( GetProcessHeap(), 0, map );
++}
++
+ void info_win32_processes(void)
+ {
+     HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+@@ -565,6 +684,54 @@ void info_win32_processes(void)
+     }
+ }
+ 
++void info_win32_processes_map(void)
++{
++    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
++    if (snap != INVALID_HANDLE_VALUE)
++    {
++        struct dump_proc  dp;
++        unsigned          i, first = -1;
++        BOOL              ok;
++
++        dp.count   = 0;
++        dp.alloc   = 16;
++        dp.entries = HeapAlloc(GetProcessHeap(), 0, sizeof(*dp.entries) * dp.alloc);
++        if (!dp.entries)
++        {
++             CloseHandle(snap);
++             return;
++        }
++        dp.entries[dp.count].proc.dwSize = sizeof(dp.entries[dp.count].proc);
++        ok = Process32First(snap, &dp.entries[dp.count].proc);
++
++        /* fetch all process information into dp (skipping this debugger) */
++        while (ok)
++        {
++            if (dp.entries[dp.count].proc.th32ProcessID != GetCurrentProcessId())
++                dp.entries[dp.count++].children = -1;
++            if (dp.count >= dp.alloc)
++            {
++                dp.entries = HeapReAlloc(GetProcessHeap(), 0, dp.entries, sizeof(*dp.entries) * (dp.alloc *= 2));
++                if (!dp.entries) return;
++            }
++            dp.entries[dp.count].proc.dwSize = sizeof(dp.entries[dp.count].proc);
++            ok = Process32Next(snap, &dp.entries[dp.count].proc);
++        }
++        CloseHandle(snap);
++        /* chain the siblings wrt. their parent */
++        for (i = 0; i < dp.count; i++)
++        {
++            unsigned parent = get_parent(&dp, i);
++            unsigned *chain = parent == -1 ? &first : &dp.entries[parent].children;
++            dp.entries[i].sibling = *chain;
++            *chain = i;
++        }
++        dbg_printf(" %-8.8s %-8.8s %-8.8s %s (all id:s are in hex)\n", "pid", "unix_pid", "threads", "executable");
++        dump_proc_info_map(&dp, first, 0);
++        HeapFree(GetProcessHeap(), 0, dp.entries);
++    }
++}
++
+ static BOOL get_process_name(DWORD pid, PROCESSENTRY32W* entry)
+ {
+     BOOL   ret = FALSE;
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
This patch adds a new info command `processmap` to winedbg, which produces the following output:
``` 
Wine-dbg>info procmap
 pid      unix_pid threads  executable (all id:s are in hex)
 0000004c 0000772d 3        'explorer.exe'
 00000038 00007729 7        'services.exe'
 000000d8 0000773b 6        \_ 'rpcss.exe'
 000000b8 00007737 3        \_ 'svchost.exe'
 000000a0 00007732 4        \_ 'plugplay.exe'
 0000006c 0000772f 7        \_ 'winedevice.exe'
 00000044 0000772b 6        \_ 'winedevice.exe'
 00000020 0000771e 1        'start.exe'
 00000128 0000775e 2        \_ 'conhost.exe'
```