### PR TITLE
Protonify wine build

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -154,7 +154,7 @@ _win10_default="false"
 
 # Other misc proton patches and hacks - Notably contains fixes for some native vk games (such as Doom Eternal) as well as Rockstar launcher
 # Also enables some winevulkan performance optimizations - https://github.com/Joshua-Ashton/proton-wine/tree/winevulkan-opt (fs hack) - https://github.com/Joshua-Ashton/wine/commits/winevulkan-opt-mainline (no fs hack)
-_protonify="false"
+_protonify="true"
 
 
 #### USER PATCHES - See README in ./wine-tkg-userpatches dir for instructions ####


### PR DESCRIPTION
> Other misc proton patches and hacks - Notably contains fixes for some native vk games (such as Doom Eternal) as well as Rockstar launcher
> Also enables some winevulkan performance optimizations - https://github.com/Joshua-Ashton/proton-wine/tree/winevulkan-opt (fs hack) - https://github.com/Joshua-Ashton/wine/commits/winevulkan-opt-mainline (no fs hack)

Fixes CEF loading times taking up to multiple minutes in Browsingway and NextUI (or really anything else that uses CEF inside the wine prefix)

Runs probably better on deck, maybe worse with some exotic window managers... (hopefully not)