### PR TITLE
Enable proton fshack

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -148,7 +148,7 @@ _FS_bypass_compositor="false"
 
 # Proton Fullscreen patch - Requires 3.16+ for staging and 5.0+ for mainline - Allows resolution changes for fullscreen games without changing desktop resolution
 # You can optionally use nearest neighbour upscaling with the WINE_FULLSCREEN_INTEGER_SCALING envvar
-_proton_fs_hack="false"
+_proton_fs_hack="true"
 
 # Proton compatible rawinput patchset - Only effective when _proton_fs_hack is set to "true" - Requires a tree containing 6d7828e8df68178ca662bc618f7598254afcfbe1 (4.20+)
 _proton_rawinput="true"


### PR DESCRIPTION
Allows ingame resolution to be changed in fullscreen mode without changing desktop resolution as well. This can be problematic if your current displaysettings aren't your monitor's default. For example, my displayscaling changes every time my monitor's resolution gets changed.