### PR TITLE
Update Wine-xiv-git with proton-bcrypt patch removed

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -53,7 +53,7 @@ _plain_version=""
 _use_staging="true"
 # staging commit or version tag if you want to use a specific staging version. Can use e.g. "7cfceb7", "v3.16" or "v4.0"
 # Leave empty to use latest master - https://github.com/wine-staging/wine-staging/commits/master
-_staging_version=""
+_staging_version="4211bac7"
 
 # NTsync - Disable with WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable NTsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
 # more info about NTsync and feedback topic - https://github.com/Frogging-Family/wine-tkg-git/issues/936

--- a/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
@@ -191,7 +191,7 @@ _sdl_joy_support="false"
 _large_address_aware="true"
 
 # Proton Bcrypt patches - Fixes RDR2 online, notably - Replaces Staging's bcrypt-ECDHSecretAgreement
-_proton_bcrypt="true"
+_proton_bcrypt="false"
 
 
 #### USER PATCHES - See README in ./wine-tkg-userpatches dir for instructions ####


### PR DESCRIPTION
The proton bcrypt patch causes a number of networking issues with Dalamud and win10/wine by removing pseudo-handles for bcrypt. Turning this patch off puts the handles back in, and makes them work with wine set to win10. Applies to wine >= 7.18.