### PR TITLE
Fix Ubuntu CI by updating to ubuntu-22.04

### DIFF
--- a/.github/workflows/wine-arch.yml
+++ b/.github/workflows/wine-arch.yml
@@ -19,7 +19,8 @@ jobs:
           chown user -R . && cd wine-tkg-git
           # Workaround for jack&jack2 conflict https://github.com/Frogging-Family/wine-tkg-git/issues/237
           sed -i "/'jack2'                 'lib32-jack2'/d" PKGBUILD
-          sed -i "/'gst-plugins-good'      'lib32-gst-plugins-good'/d" PKGBUILD 
+          sed -i "/'gst-plugins-good'      'lib32-gst-plugins-good'/d" PKGBUILD
+          sed -i 's/pkgname=wine-tkg/pkgname=wine-xiv/' PKGBUILD
           sed -i 's/wayland_driver="false"/wayland_driver="true"/' customization.cfg
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 

--- a/.github/workflows/wine-fedora.yml
+++ b/.github/workflows/wine-fedora.yml
@@ -16,7 +16,7 @@ jobs:
           sudo dnf -y -q upgrade --refresh
           cd wine-tkg-git 
           sed -i 's/distro=""/distro="fedora"/' customization.cfg
-          sed -i 's/_wayland_driver="false"/_wayland_driver="true"' customization.cfg
+          sed -i 's/_wayland_driver="false"/_wayland_driver="true"/' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg
           echo '_ci_build="true"' >> customization.cfg
           touch tarplz

--- a/.github/workflows/wine-fedora.yml
+++ b/.github/workflows/wine-fedora.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Compilation
         run: |
           sudo dnf -y -q upgrade --refresh
-          cd wine-tkg-git 
+          cd wine-tkg-git
+          sed -i 's/pkgname=wine-tkg/pkgname=wine-xiv/' non-makepkg-build.sh
           sed -i 's/distro=""/distro="fedora"/' customization.cfg
           sed -i 's/_wayland_driver="false"/_wayland_driver="true"/' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg

--- a/.github/workflows/wine-fedora.yml
+++ b/.github/workflows/wine-fedora.yml
@@ -16,6 +16,7 @@ jobs:
           sudo dnf -y -q upgrade --refresh
           cd wine-tkg-git 
           sed -i 's/distro=""/distro="fedora"/' customization.cfg
+          sed -i 's/_wayland_driver="false"/_wayland_driver="true"' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg
           echo '_ci_build="true"' >> customization.cfg
           touch tarplz

--- a/.github/workflows/wine-ubuntu.yml
+++ b/.github/workflows/wine-ubuntu.yml
@@ -17,7 +17,8 @@ jobs:
           sudo apt install aptitude
           sudo aptitude remove -y '?narrow(?installed,?version(deb.sury.org))'
           sudo apt install libxkbregistry-dev
-          cd wine-tkg-git 
+          cd wine-tkg-git
+          sed -i 's/pkgname=wine-tkg/pkgname=wine-xiv/' non-makepkg-build.sh
           sed -i 's/distro=""/distro="debuntu"/' customization.cfg
           sed -i 's/_wayland_driver="false"/_wayland_driver="true"/' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg

--- a/.github/workflows/wine-ubuntu.yml
+++ b/.github/workflows/wine-ubuntu.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt install libxkbregistry-dev
           cd wine-tkg-git 
           sed -i 's/distro=""/distro="debuntu"/' customization.cfg
-          sed -i 's/_wayland_driver="false"/_wayland_driver="true"' customization.cfg
+          sed -i 's/_wayland_driver="false"/_wayland_driver="true"/' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg
           echo '_ci_build="true"' >> customization.cfg
           touch tarplz

--- a/.github/workflows/wine-ubuntu.yml
+++ b/.github/workflows/wine-ubuntu.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
 
@@ -16,8 +16,10 @@ jobs:
           sudo dpkg --add-architecture i386 && sudo apt update
           sudo apt install aptitude
           sudo aptitude remove -y '?narrow(?installed,?version(deb.sury.org))'
+          sudo apt install libxkbregistry-dev
           cd wine-tkg-git 
           sed -i 's/distro=""/distro="debuntu"/' customization.cfg
+          sed -i 's/_wayland_driver="false"/_wayland_driver="true"' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg
           echo '_ci_build="true"' >> customization.cfg
           touch tarplz


### PR DESCRIPTION
This should be ready to go. I also enabled the wayland driver on the ubuntu and fedora builds (it was already enabled on arch). It's reasonably functional at this point.

~Updated CI to use ubuntu-22.04. This should build. Cross your fingers.~

~Moved the build into a container instead of building directly in the CI instance. This fixes the dependency hell and allows it to build.~

By the way, the sed -i 's/distro.../' line is no longer necessary, as the script now auto-detects the distro it's building in.