### PR TITLE
Update to wine-staging 10.7

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -55,7 +55,7 @@ _plain_version=""
 _use_staging="true"
 # staging commit or version tag if you want to use a specific staging version. Can use e.g. "7cfceb7", "v3.16" or "v4.0"
 # Leave empty to use latest master - https://github.com/wine-staging/wine-staging/commits/master
-_staging_version="v10.6"
+_staging_version="v10.7"
 
 # NTsync - Disable with WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable NTsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
 # more info about NTsync and feedback topic - https://github.com/Frogging-Family/wine-tkg-git/issues/936


### PR DESCRIPTION
This will update wine to 10.7, which is the last version that works with the current portable-pdb patch. 